### PR TITLE
Pass on device ID

### DIFF
--- a/src/main/java/rtlspektrum/Rtlspektrum.java
+++ b/src/main/java/rtlspektrum/Rtlspektrum.java
@@ -143,7 +143,7 @@ public class Rtlspektrum
 	public int openDevice(){
 		int ret = 0;
 		Pointer<Pointer> ppdev = Pointer.pointerToPointer(dev);
-		ret = RtlsdrLibrary.rtlsdr_open(ppdev, 0);
+		ret = RtlsdrLibrary.rtlsdr_open(ppdev, deviceId);
 
 		if(ret >= 0) {
 			dev = ppdev.get();


### PR DESCRIPTION
This enables you to choose your device.
I had an issue since my SDR gives two different names and with the current code no matter which one we select only the first one (0) is selected, code tested and working.