### PR TITLE
Rtlspektrum.java:  Add device serial number to the device string

### DIFF
--- a/src/main/java/rtlspektrum/Rtlspektrum.java
+++ b/src/main/java/rtlspektrum/Rtlspektrum.java
@@ -60,12 +60,16 @@ public class Rtlspektrum
 
 	public static String[] getDevices() {
 		loadNativeLibs();
-		
+
 		int deviceCount = RtlsdrLibrary.rtlsdr_get_device_count();
 		String[] ret = new String[deviceCount];
+		Pointer<Byte> serial = Pointer.allocateBytes(256);
+
 		for(int i = 0;i<deviceCount;i++){
-			ret[i] = RtlsdrLibrary.rtlsdr_get_device_name(i).getCString();
+			RtlsdrLibrary.rtlsdr_get_device_usb_strings(i, null, null, serial);
+			ret[i] = RtlsdrLibrary.rtlsdr_get_device_name(i).getCString() + ": " + serial.getCString();
 		}
+		serial.release();
 		return ret;
 	}
 


### PR DESCRIPTION
Most folks with mutiple SDRs use rtl_eeprom to set their serial
numbers to unique values so you can tell them apart.
Rtlspektrum.getDevices() doesn't return it though so when you open
Spektrum you get a list of devices that all look the same.

* Rtlspektrum.getDevices() now appends the serial number as follows:
`"<devicetype>: <serial>"`

Spektrum needs to be rebuilt to pick up this change but no other
Spektrum changes are required.